### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/app/src/main/java/com/frodo/app/android/core/network/AndroidNetworkSystem.java
+++ b/app/src/main/java/com/frodo/app/android/core/network/AndroidNetworkSystem.java
@@ -65,7 +65,7 @@ public class AndroidNetworkSystem extends AbstractChildSystem implements Network
 
     @Override
     public boolean isGpsEnabled() {
-        LocationManager lm = ((LocationManager) context.getSystemService(Context.LOCATION_SERVICE));
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
         List<String> accessibleProviders = lm.getProviders(true);
         return accessibleProviders != null && accessibleProviders.size() > 0;
     }
@@ -73,8 +73,8 @@ public class AndroidNetworkSystem extends AbstractChildSystem implements Network
     @Override
     public boolean isWifiEnabled() {
         TelephonyManager mgrTel = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-        return ((getNetworkInfo() != null && getNetworkInfo().getState() == NetworkInfo.State.CONNECTED) || mgrTel
-                .getNetworkType() == TelephonyManager.NETWORK_TYPE_UMTS);
+        return (getNetworkInfo() != null && getNetworkInfo().getState() == NetworkInfo.State.CONNECTED) || mgrTel
+                .getNetworkType() == TelephonyManager.NETWORK_TYPE_UMTS;
     }
 
     @Override

--- a/app/src/main/java/com/frodo/app/android/core/toolbox/DensityUtils.java
+++ b/app/src/main/java/com/frodo/app/android/core/toolbox/DensityUtils.java
@@ -46,7 +46,7 @@ public class DensityUtils {
      */
     public static float px2dp(Context context, float pxVal) {
         final float scale = context.getResources().getDisplayMetrics().density;
-        return (pxVal / scale);
+        return pxVal / scale;
     }
 
     /**
@@ -57,6 +57,6 @@ public class DensityUtils {
      * @return
      */
     public static float px2sp(Context context, float pxVal) {
-        return (pxVal / context.getResources().getDisplayMetrics().scaledDensity);
+        return pxVal / context.getResources().getDisplayMetrics().scaledDensity;
     }
 }

--- a/simple/src/main/java/com/frodo/app/android/simple/MovieView.java
+++ b/simple/src/main/java/com/frodo/app/android/simple/MovieView.java
@@ -110,7 +110,7 @@ public class MovieView extends UIView {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 // only for test redirect function
-                FragmentScheduler.nextFragment(((FragmentContainerActivity) getPresenter().getAndroidContext()), RedirectFragment.class, null, false);
+                FragmentScheduler.nextFragment((FragmentContainerActivity) getPresenter().getAndroidContext(), RedirectFragment.class, null, false);
             }
         });
     }

--- a/simple/src/main/java/com/frodo/app/android/simple/SplashFragment.java
+++ b/simple/src/main/java/com/frodo/app/android/simple/SplashFragment.java
@@ -37,7 +37,7 @@ public class SplashFragment extends AbstractBaseFragment {
                 ad.postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        FragmentScheduler.nextFragment(((FragmentContainerActivity) getActivity()), MovieFragment.class, null, true);
+                        FragmentScheduler.nextFragment((FragmentContainerActivity) getActivity(), MovieFragment.class, null, true);
                     }
                 }, 5000);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck  Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck  

Please let me know if you have any questions.

Zeeshan Asghar
