### PR TITLE
Unused private fields should be removed

### DIFF
--- a/app/src/main/java/com/frodo/app/android/core/cache/AndroidCacheSystem.java
+++ b/app/src/main/java/com/frodo/app/android/core/cache/AndroidCacheSystem.java
@@ -25,18 +25,14 @@ public class AndroidCacheSystem extends AbstractChildSystem implements CacheSyst
     private Context context;
     private String cacheDir;
 
-    private AndroidCacheSharedPreferences sharedPreferences;
     private FileSystem fileSystem;
-    private Database database;
 
     public AndroidCacheSystem(IController controller, String cacheDir) {
         super(controller);
         this.context = (Context) controller.getMicroContext();
         this.cacheDir = cacheDir;
 
-        this.sharedPreferences = new AndroidCacheSharedPreferences(context);
         this.fileSystem = controller.getFileSystem();
-        this.database = controller.getDatabase();
     }
 
     @Override

--- a/framework/src/main/java/com/frodo/app/framework/net/Request.java
+++ b/framework/src/main/java/com/frodo/app/framework/net/Request.java
@@ -16,7 +16,6 @@ import java.util.Map;
 public final class Request {
     private final String method;
     private String relativeUrl;
-    private final Map<String, Object> params;
     private final List<Header> headers;
     private final TypedOutput body;
 
@@ -40,12 +39,6 @@ public final class Request {
             this.headers = Collections.emptyList();
         } else {
             this.headers = headers;
-        }
-
-        if (params == null) {
-            this.params = new HashMap<>();
-        } else {
-            this.params = params;
         }
 
         this.body = body;

--- a/simple/src/main/java/com/frodo/app/android/simple/Base64.java
+++ b/simple/src/main/java/com/frodo/app/android/simple/Base64.java
@@ -29,9 +29,6 @@ public class Base64 {
     public static final int DO_BREAK_LINES = 8;
     public static final int URL_SAFE = 16;
     public static final int ORDERED = 32;
-    private static final int MAX_LINE_LENGTH = 76;
-    private static final byte EQUALS_SIGN = 61;
-    private static final byte NEW_LINE = 10;
     private static final String PREFERRED_ENCODING = "US-ASCII";
     private static final byte WHITE_SPACE_ENC = -5;
     private static final byte EQUALS_SIGN_ENC = -1;

--- a/simple/src/main/java/com/frodo/app/android/simple/MovieFragment.java
+++ b/simple/src/main/java/com/frodo/app/android/simple/MovieFragment.java
@@ -27,7 +27,6 @@ import rx.schedulers.Schedulers;
  * Created by frodo on 2015/4/2.
  */
 public class MovieFragment extends StatedFragment<MovieView, MovieModel> {
-    private static final String[] DEFAULT = {"rxjava, movie"};
 
     @Override
     public MovieView createUIView(Context context, LayoutInflater inflater, ViewGroup container) {

--- a/test/src/test/java/com/frodo/android/test/notes/notes/NotesPresenterTest.java
+++ b/test/src/test/java/com/frodo/android/test/notes/notes/NotesPresenterTest.java
@@ -45,8 +45,6 @@ public class NotesPresenterTest {
     private static List<Note> NOTES = Lists.newArrayList(new Note("Title1", "Description1"),
             new Note("Title2", "Description2"));
 
-    private static List<Note> EMPTY_NOTES = new ArrayList<>(0);
-
     @Mock
     private NotesRepository mNotesRepository;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1068 Unused private fields should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1068 

Please let me know if you have any questions.

Zeeshan Asghar
